### PR TITLE
Fix History REST API

### DIFF
--- a/tests/test_history_server.py
+++ b/tests/test_history_server.py
@@ -77,8 +77,8 @@ class HistoryServerTestCase(TestCase):
 
     def test_task_attempt(self, request_mock):
         self.hs.task_attempt('job_2', 'task_3', 'attempt_4')
-        request_mock.assert_called_with('/ws/v1/history/mapreduce/jobs/job_2/tasks/task_3/attempt/attempt_4')
+        request_mock.assert_called_with('/ws/v1/history/mapreduce/jobs/job_2/tasks/task_3/attempts/attempt_4')
 
     def test_task_attempt_counters(self, request_mock):
         self.hs.task_attempt_counters('job_2', 'task_3', 'attempt_4')
-        request_mock.assert_called_with('/ws/v1/history/mapreduce/jobs/job_2/tasks/task_3/attempt/attempt_4/counters')
+        request_mock.assert_called_with('/ws/v1/history/mapreduce/jobs/job_2/tasks/task_3/attempts/attempt_4/counters')

--- a/yarn_api_client/__init__.py
+++ b/yarn_api_client/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-__version__ = '0.2.4'
+__version__ = '0.2.5'
 __all__ = ['ApplicationMaster', 'HistoryServer', 'NodeManager',
            'ResourceManager']
 

--- a/yarn_api_client/base.py
+++ b/yarn_api_client/base.py
@@ -38,7 +38,8 @@ class BaseYarnAPI(object):
         if response.status == OK:
             return self.response_class(response)
         else:
-            msg = 'Response finished with status: %s' % response.status
+            explanation = response.read()
+            msg = 'Response finished with status: %s. Details: %s' % (response.status, explanation)
             raise APIError(msg)
 
     def construct_parameters(self, arguments):

--- a/yarn_api_client/history_server.py
+++ b/yarn_api_client/history_server.py
@@ -216,7 +216,7 @@ class HistoryServer(BaseYarnAPI):
         :returns: API response object with JSON data
         :rtype: :py:class:`yarn_api_client.base.Response`
         """
-        path = '/ws/v1/history/mapreduce/jobs/{jobid}/tasks/{taskid}/attempt/{attemptid}'.format(
+        path = '/ws/v1/history/mapreduce/jobs/{jobid}/tasks/{taskid}/attempts/{attemptid}'.format(
             jobid=job_id, taskid=task_id, attemptid=attempt_id)
 
         return self.request(path)
@@ -232,7 +232,7 @@ class HistoryServer(BaseYarnAPI):
         :returns: API response object with JSON data
         :rtype: :py:class:`yarn_api_client.base.Response`
         """
-        path = '/ws/v1/history/mapreduce/jobs/{jobid}/tasks/{taskid}/attempt/{attemptid}/counters'.format(
+        path = '/ws/v1/history/mapreduce/jobs/{jobid}/tasks/{taskid}/attempts/{attemptid}/counters'.format(
             jobid=job_id, taskid=task_id, attemptid=attempt_id)
 
         return self.request(path)


### PR DESCRIPTION
Use attempts/xxx to access attempt info in Hadoop 2.6
I do not have currently older Hadoop version to check
