### PR TITLE
Bug with Python 3: "TypeError: the JSON object must be str, not 'bytes'"

### DIFF
--- a/yarn_api_client/base.py
+++ b/yarn_api_client/base.py
@@ -12,11 +12,13 @@ except ImportError:
     from urllib.parse import urlencode
 
 from .errors import APIError, ConfigurationError
+import codecs
 
 
 class Response(object):
     def __init__(self, http_response):
-        self.data = json.load(http_response)
+        reader = codecs.getreader("utf-8")
+        self.data = json.load(reader(http_response))
 
 
 class BaseYarnAPI(object):


### PR DESCRIPTION
I had the following issue with Python 3 without this modification:

`TypeError: the JSON object must be str, not 'bytes'`

It seems to work nicely with Python 3.5.1 and Python 2.7.11.
But I might have needed the change due to a misconfiguration of my test server...
