### PR TITLE
Fixed encoding bug in python3

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -4,7 +4,7 @@ try:
 except ImportError:
     from http.client import OK
 
-from mock import patch
+from mock import patch, MagicMock
 from tests import TestCase
 
 from yarn_api_client import base
@@ -17,6 +17,9 @@ class BaseYarnAPITestCase(TestCase):
         with patch('yarn_api_client.base.HTTPConnection') as http_conn_mock:
             with patch('yarn_api_client.base.json'):
                 http_conn_mock().getresponse().status = OK
+                headers_mock = MagicMock()
+                headers_mock.get_content_charset = MagicMock(return_value="utf-8")
+                http_conn_mock().getresponse().headers = headers_mock
 
                 client.request('/ololo', foo='bar')
 

--- a/yarn_api_client/base.py
+++ b/yarn_api_client/base.py
@@ -16,7 +16,7 @@ from .errors import APIError, ConfigurationError
 
 class Response(object):
     def __init__(self, http_response):
-        self.data = json.load(http_response)
+        self.data = json.loads(http_response.read().decode(http_response.headers.get_content_charset('utf-8')))
 
 
 class BaseYarnAPI(object):


### PR DESCRIPTION
- Happens because python3 HTTPResponse, when read like a file (e.g. with `json.load`), assumes binary
- see: https://stackoverflow.com/questions/23049767/parsing-http-response-in-python
- Updated test mocks to make unit tests pass
- Related to https://github.com/toidi/hadoop-yarn-api-python-client/pull/7 , which has a *similar* fix: the main difference is that this fix reads the response's encoding field, just incase it is non-utf8
