### PR TITLE
Fix cluster_application_kill method

### DIFF
--- a/yarn_api_client/resource_manager.py
+++ b/yarn_api_client/resource_manager.py
@@ -213,7 +213,7 @@ class ResourceManager(BaseYarnAPI):
         path = '/ws/v1/cluster/apps/{appid}/state'.format(
             appid=application_id)
 
-        return self.put(path, data)
+        return self.update(path, data)
 
     def cluster_nodes(self, state=None, healthy=None):
         """


### PR DESCRIPTION
The recently introduced cluster_application_kill() method was erroneously
calling `self.put()` to issue the status change to `KILLED`.  This resulted
in an AttributeError exception:
```
''ResourceManager' object has no attribute 'put''
```
in client code.

The base class issues put calls, via its `update()` method.  Once updated,
application kill requests succeed.