### PR TITLE
check for HADOOP_CONF_DIR env var

### DIFF
--- a/yarn_api_client/hadoop_conf.py
+++ b/yarn_api_client/hadoop_conf.py
@@ -6,7 +6,7 @@ try:
 except ImportError:
     from http.client import HTTPConnection, OK
 
-CONF_DIR = '/etc/hadoop/conf'
+CONF_DIR = os.getenv('HADOOP_CONF_DIR', '/etc/hadoop/conf')
 
 
 def _get_rm_ids(hadoop_conf_path):


### PR DESCRIPTION
Hello @toidi 

When setting `CONF_DIR` in `yarn_api_client/hadoop_conf.py` it would be nice to check for conf dir overrides defined via the `HADOOP_CONF_DIR` env var. Comes in handy when working with hadoop clients defined in non standard paths.

Impact should be super minimal. Appreciate the consideration.

Cheers!