### PR TITLE
Add support for handling multiple RMs sans Hadoop config

### DIFF
--- a/tests/test_hadoop_conf.py
+++ b/tests/test_hadoop_conf.py
@@ -70,7 +70,7 @@ class HadoopConfTestCase(TestCase):
 
     @mock.patch('yarn_api_client.hadoop_conf._get_rm_ids')
     @mock.patch('yarn_api_client.hadoop_conf.parse')
-    @mock.patch('yarn_api_client.hadoop_conf._check_is_active_rm')
+    @mock.patch('yarn_api_client.hadoop_conf.check_is_active_rm')
     def test_get_resource_host_port_with_ha(self, check_is_active_rm_mock, parse_mock, get_rm_ids_mock):
         get_rm_ids_mock.return_value = ['rm1', 'rm2']
         parse_mock.return_value = 'example.com:8022'
@@ -116,17 +116,17 @@ class HadoopConfTestCase(TestCase):
 
         http_conn_request_mock.return_value = None
         http_getresponse_mock.return_value = ResponseMock(OK, {})
-        self.assertTrue(hadoop_conf._check_is_active_rm('example2', '8022'))
+        self.assertTrue(hadoop_conf.check_is_active_rm('example2', '8022'))
         http_getresponse_mock.reset_mock()
         http_getresponse_mock.return_value = ResponseMock(OK, {'Refresh': "testing"})
-        self.assertFalse(hadoop_conf._check_is_active_rm('example2', '8022'))
+        self.assertFalse(hadoop_conf.check_is_active_rm('example2', '8022'))
         http_getresponse_mock.reset_mock()
         http_getresponse_mock.return_value = ResponseMock(NOT_FOUND, {'Refresh': "testing"})
-        self.assertFalse(hadoop_conf._check_is_active_rm('example2', '8022'))
+        self.assertFalse(hadoop_conf.check_is_active_rm('example2', '8022'))
         http_conn_request_mock.side_effect = Exception('error')
         http_conn_request_mock.reset_mock()
         http_conn_request_mock.return_value = None
-        self.assertFalse(hadoop_conf._check_is_active_rm('example2', '8022'))
+        self.assertFalse(hadoop_conf.check_is_active_rm('example2', '8022'))
         pass
 
     def test_get_resource_manager(self):

--- a/yarn_api_client/hadoop_conf.py
+++ b/yarn_api_client/hadoop_conf.py
@@ -29,7 +29,7 @@ def _get_resource_manager(hadoop_conf_path, rm_id=None):
         return None
 
 
-def _check_is_active_rm(rm_web_host, rm_web_port):
+def check_is_active_rm(rm_web_host, rm_web_port):
     conn = HTTPConnection(rm_web_host, rm_web_port)
     try:
         conn.request('GET', '/cluster')
@@ -52,7 +52,7 @@ def get_resource_manager_host_port():
             ret = _get_resource_manager(hadoop_conf_path, rm_id)
             if ret is not None:
                 (host, port) = ret
-                if _check_is_active_rm(host, port):
+                if check_is_active_rm(host, port):
                     return host, port
         return None
     else:


### PR DESCRIPTION
Alternate address and port parameters can now be passed to the ResourceManager
constructor.  ~This has been facilitated via a keyword args dict (kwargs) to 
accommodate future parameters.~  If both `address` and `alt_address` are provided,
`address` and `port` will be used to determine if the RM is active.  If not, then
`alt_address` and `alt_port` will be used.  If the latter is active, the address
and port member variables are reset to reflect the alternates.

Also added method `get_active_host_port()` to return the address, port tuple currently
in use for the ResourceManager instance.  This is helpful to clients in cases where
the address was None or HA is configured.

Fixes: #9 

EDIT: Removed use of `kwargs` per review comment.