### PR TITLE
Fix POST response code API handling

### DIFF
--- a/yarn_api_client/base.py
+++ b/yarn_api_client/base.py
@@ -44,7 +44,7 @@ class BaseYarnAPI(object):
         else:
             response = requests.request(method=method, url=api_endpoint, headers=headers, **kwargs)
 
-        if response.status_code == requests.codes.ok:
+        if response.status_code in (200, 202):
             return self.response_class(response)
         else:
             msg = 'Response finished with status: %s. Details: %s' % (response.status_code, response.text)


### PR DESCRIPTION
POST api is responding with response code 202 instead of 200
https://hadoop.apache.org/docs/r2.7.3/hadoop-yarn/hadoop-yarn-site/ResourceManagerRest.html#Cluster_New_Application_API