### PR TITLE
[HOTFIX] Fix how params dict is passed to request()

### DIFF
--- a/tests/test_resource_manager.py
+++ b/tests/test_resource_manager.py
@@ -31,17 +31,16 @@ class ResourceManagerTestCase(TestCase):
 
     def test_cluster_applications(self, request_mock):
         self.rm.cluster_applications()
-        request_mock.assert_called_with('/ws/v1/cluster/apps')
+        request_mock.assert_called_with('/ws/v1/cluster/apps', params={})
 
         self.rm.cluster_applications(state='KILLED', final_status='FAILED',
                                      user='root', queue='low', limit=10,
                                      started_time_begin=1, started_time_end=2,
                                      finished_time_begin=3, finished_time_end=4)
-        request_mock.assert_called_with('/ws/v1/cluster/apps', state='KILLED',
-                                        finalStatus='FAILED', user='root',
-                                        queue='low', limit=10,
-                                        startedTimeBegin=1, startedTimeEnd=2,
-                                        finishedTimeBegin=3, finishedTimeEnd=4)
+        request_mock.assert_called_with('/ws/v1/cluster/apps', params={'state': 'KILLED',
+                                        'finalStatus': 'FAILED', 'user': 'root', 'queue': 'low',
+                                        'limit': 10, 'startedTimeBegin': 1, 'startedTimeEnd': 2,
+                                        'finishedTimeBegin': 3, 'finishedTimeEnd': 4})
 
         with self.assertRaises(IllegalArgumentError):
             self.rm.cluster_applications(state='ololo')
@@ -51,7 +50,7 @@ class ResourceManagerTestCase(TestCase):
 
     def test_cluster_application_statistics(self, request_mock):
         self.rm.cluster_application_statistics()
-        request_mock.assert_called_with('/ws/v1/cluster/appstatistics')
+        request_mock.assert_called_with('/ws/v1/cluster/appstatistics', params={})
         # TODO: test arguments
 
     def test_cluster_application(self, request_mock):

--- a/yarn_api_client/resource_manager.py
+++ b/yarn_api_client/resource_manager.py
@@ -135,7 +135,7 @@ class ResourceManager(BaseYarnAPI):
 
         params = self.construct_parameters(loc_args)
 
-        return self.request(path, **params)
+        return self.request(path, params=params)
 
     def cluster_application_statistics(self, state_list=None,
                                        application_type_list=None):
@@ -174,7 +174,7 @@ class ResourceManager(BaseYarnAPI):
             ('applicationTypes', application_types))
         params = self.construct_parameters(loc_args)
 
-        return self.request(path, **params)
+        return self.request(path, params=params)
 
     def cluster_application(self, application_id):
         """


### PR DESCRIPTION
The params dict was being passed as a kwargs parameter (`**params`)
rather than as a kwarg itself (e.g., `params=params`).  As a result,
the change in the `request()` method was passing each of the parameters
intended for the YARN RM as keyword arguments to the `requests()` method
itself.  This produced the following error on such requests...

```
<class 'TypeError'> - 'request() got an unexpected keyword argument
'startedTimeBegin'
```

resulting in failures in `0.3.4`.