### PR TITLE
Honor http policy

### DIFF
--- a/tests/test_resource_manager.py
+++ b/tests/test_resource_manager.py
@@ -4,6 +4,7 @@ from tests import TestCase
 
 from yarn_api_client.resource_manager import ResourceManager
 from yarn_api_client.errors import IllegalArgumentError
+from yarn_api_client.hadoop_conf import _is_https_only
 
 
 @patch('yarn_api_client.resource_manager.ResourceManager.request')
@@ -11,11 +12,19 @@ class ResourceManagerTestCase(TestCase):
     def setUp(self):
         self.rm = ResourceManager('localhost')
 
+    @patch('yarn_api_client.resource_manager._is_https_only')
     @patch('yarn_api_client.resource_manager.get_resource_manager_host_port')
-    def test__init__(self, get_config_mock, request_mock):
-        get_config_mock.return_value = (None, None)
-        ResourceManager()
+    def test__init__(self, get_config_mock, is_https_only_mock, request_mock):
+        get_config_mock.return_value = ('example', '8024')
+        is_https_only_mock.return_value = True
+
+        rm = ResourceManager()
+
         get_config_mock.assert_called_with()
+        self.assertEqual(rm.address, 'example')
+        self.assertEqual(rm.port, '8024')
+        is_https_only_mock.assert_called_with()
+        self.assertEqual(rm.is_https, True)
 
     def test_cluster_information(self, request_mock):
         self.rm.cluster_information()

--- a/yarn_api_client/base.py
+++ b/yarn_api_client/base.py
@@ -16,8 +16,9 @@ class BaseYarnAPI(object):
     __logger = None
     response_class = Response
 
-    def __init__(self, address=None, port=None, timeout=None, kerberos_enabled=None):
-        self.address, self.port, self.timeout, self.kerberos_enabled = address, port, timeout, kerberos_enabled
+    def __init__(self, address=None, port=None, timeout=None, kerberos_enabled=None, is_https=False):
+        self.address, self.port, self.timeout, self.kerberos_enabled, self.is_https = \
+            address, port, timeout, kerberos_enabled, is_https
 
     def _validate_configuration(self):
         if self.address is None:
@@ -26,7 +27,8 @@ class BaseYarnAPI(object):
             raise ConfigurationError('API port is not set')
 
     def request(self, api_path, method='GET', **kwargs):
-        api_endpoint = 'http://{}:{}{}'.format(self.address, self.port, api_path)
+        scheme = 'https' if self.is_https else 'http'
+        api_endpoint = '{}://{}:{}{}'.format(scheme, self.address, self.port, api_path)
 
         self.logger.info('API Endpoint {}'.format(api_endpoint))
 

--- a/yarn_api_client/hadoop_conf.py
+++ b/yarn_api_client/hadoop_conf.py
@@ -2,9 +2,9 @@
 import os
 import xml.etree.ElementTree as ET
 try:
-    from httplib import HTTPConnection, OK
+    from httplib import HTTPConnection, HTTPSConnection, OK
 except ImportError:
-    from http.client import HTTPConnection, OK
+    from http.client import HTTPConnection, HTTPSConnection, OK
 
 CONF_DIR = os.getenv('HADOOP_CONF_DIR', '/etc/hadoop/conf')
 
@@ -15,25 +15,45 @@ def _get_rm_ids(hadoop_conf_path):
         rm_ids = rm_ids.split(',')
     return rm_ids
 
+
 def _get_maximum_container_memory(hadoop_conf_path):
     container_memory = int(parse(os.path.join(hadoop_conf_path,'yarn-site.xml'), 'yarn.nodemanager.resource.memory-mb'))
     return container_memory
 
+
+def _is_https_only():
+    # determine if HTTPS_ONLY is the configured policy, else use http
+    hadoop_conf_path = CONF_DIR
+    http_policy = parse(os.path.join(hadoop_conf_path, 'yarn-site.xml'), 'yarn.http.policy')
+    if http_policy == 'HTTPS_ONLY':
+        return True
+    return False
+
+
 def _get_resource_manager(hadoop_conf_path, rm_id=None):
-    prop_name = 'yarn.resourcemanager.webapp.address'
-    if rm_id is not None:
-        rm_webapp_address = parse(os.path.join(hadoop_conf_path, 'yarn-site.xml'), '%s.%s' % (prop_name, rm_id))
+    # compose property name based on policy (and rm_id)
+    if _is_https_only():
+        prop_name = 'yarn.resourcemanager.webapp.https.address'
     else:
-        rm_webapp_address = parse(os.path.join(hadoop_conf_path, 'yarn-site.xml'), prop_name)
+        prop_name = 'yarn.resourcemanager.webapp.address'
+
+    # Adjust prop_name if rm_id is set
+    if rm_id:
+        prop_name = "{name}.{rm_id}".format(name=prop_name, rm_id=rm_id)
+
+    rm_webapp_address = parse(os.path.join(hadoop_conf_path, 'yarn-site.xml'), prop_name)
     if rm_webapp_address is not None:
         [host, port] = rm_webapp_address.split(':')
-        return (host, port)
+        return host, port
     else:
         return None
 
 
 def check_is_active_rm(rm_web_host, rm_web_port):
-    conn = HTTPConnection(rm_web_host, rm_web_port)
+    if _is_https_only():
+        conn = HTTPSConnection(rm_web_host, rm_web_port)
+    else:
+        conn = HTTPConnection(rm_web_host, rm_web_port)
     try:
         conn.request('GET', '/cluster')
     except:

--- a/yarn_api_client/resource_manager.py
+++ b/yarn_api_client/resource_manager.py
@@ -40,7 +40,6 @@ class ResourceManager(BaseYarnAPI):
                     # Default is not active, check alternate
                     if check_is_active_rm(alt_address, alt_port):
                         address, port = alt_address, alt_port
-
         super(ResourceManager, self).__init__(address, port, timeout, kerberos_enabled, is_https)
 
     def get_active_host_port(self):

--- a/yarn_api_client/resource_manager.py
+++ b/yarn_api_client/resource_manager.py
@@ -4,8 +4,10 @@ from .base import BaseYarnAPI
 from .constants import YarnApplicationState, FinalApplicationStatus
 from .errors import IllegalArgumentError
 from .hadoop_conf import get_resource_manager_host_port,\
-    check_is_active_rm, _get_maximum_container_memory, CONF_DIR
+    check_is_active_rm, _get_maximum_container_memory, CONF_DIR, \
+    _is_https_only
 from collections import deque
+
 
 class ResourceManager(BaseYarnAPI):
     """
@@ -30,14 +32,16 @@ class ResourceManager(BaseYarnAPI):
         if address is None:
             self.logger.debug('Get configuration from hadoop conf dir: {conf_dir}'.format(conf_dir=CONF_DIR))
             address, port = get_resource_manager_host_port()
+            is_https = _is_https_only()
         else:
+            is_https = False
             if alt_address:  # Determine active RM
                 if not check_is_active_rm(address, port):
                     # Default is not active, check alternate
                     if check_is_active_rm(alt_address, alt_port):
                         address, port = alt_address, alt_port
 
-        super(ResourceManager, self).__init__(address, port, timeout, kerberos_enabled)
+        super(ResourceManager, self).__init__(address, port, timeout, kerberos_enabled, is_https)
 
     def get_active_host_port(self):
         """


### PR DESCRIPTION
The current implementation does not honor the configured HTTP policy within `yarn-site.xml`.  As a result, if the HTTP policy reflects `HTTPS_ONLY`, the ResourceManager object will fail.  These changes allow for installations to leverage HTTPS **when using the default configuration**.  That is, HTTPS is still not supported if an `address` is provided to `ResourceManager` due to the fact that the protocol is not  conveyed in the request.  

Once PR #34 is merged (requires a new release), we can then interrogate the protocol to determine that HTTPS has been requested.  (Note: these changes will likely be warranted following #34's merge.)