### PR TITLE
Fix Uri object and usage issues

### DIFF
--- a/yarn_api_client/base.py
+++ b/yarn_api_client/base.py
@@ -26,10 +26,11 @@ class Uri(object):
         self.is_https = service_uri.scheme == 'https' or False
 
     def to_url(self, api_path=None):
+        path = api_path or ''
         if self.port:
-            result_url = urlunparse((self.scheme, self.hostname + ":" + self.port, api_path, None, None, None))
+            result_url = urlunparse((self.scheme, self.hostname + ":" + str(self.port), path, None, None, None))
         else:
-            result_url = urlunparse((self.scheme, self.hostname, api_path, None, None, None))
+            result_url = urlunparse((self.scheme, self.hostname, path, None, None, None))
 
         return result_url
 

--- a/yarn_api_client/hadoop_conf.py
+++ b/yarn_api_client/hadoop_conf.py
@@ -50,9 +50,9 @@ def _get_resource_manager(hadoop_conf_path, rm_id=None):
 def check_is_active_rm(url, timeout=30):
     uri = Uri(url)
     if uri.is_https:
-        conn = HTTPSConnection(host=url, timeout=timeout)
+        conn = HTTPSConnection(host=uri.hostname, port=uri.port, timeout=timeout)
     else:
-        conn = HTTPConnection(host=url, timeout=timeout)
+        conn = HTTPConnection(host=uri.hostname, port=uri.port, timeout=timeout)
     try:
         conn.request('GET', '/cluster')
     except:


### PR DESCRIPTION
Port field is an int so composition into strings requires a cast.
Pass explicit host and port to HTTPConnection initializers since
it doesn't appear to parse out the port number when a path is also
included.

Fixes #45