### PR TITLE
Release 1.0 (Redo)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
     version = find_version('yarn_api_client', '__init__.py'),
     description='Python client for Hadoop® YARN API',
     long_description=read('README.md'),
+    long_description_content_type='text/markdown',
     packages = find_packages(exclude=['tests','itests']),
 
     install_requires = [

--- a/yarn_api_client/__init__.py
+++ b/yarn_api_client/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-__version__ = '2.0.0.dev0'
+__version__ = '1.0.0'
 __all__ = ['ApplicationMaster', 'HistoryServer', 'NodeManager', 'ResourceManager']
 
 from .application_master import ApplicationMaster

--- a/yarn_api_client/__init__.py
+++ b/yarn_api_client/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-__version__ = '1.0.0'
+__version__ = '2.0.0.dev0'
 __all__ = ['ApplicationMaster', 'HistoryServer', 'NodeManager', 'ResourceManager']
 
 from .application_master import ApplicationMaster


### PR DESCRIPTION
Found that the conversion of `README.rst` to `README.md` breaks pushes to pypi.org where `setup.py` uses it for the `long_description`.  This change specifies that `text/markdown` be the expected content type for `long_description`.  (I've also already posted the build to pypi to confirm. :smile:)
