### PR TITLE
Add test suites for new python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ language: python
 
 matrix:
   include:
+    - python: 3.8
+      env: TOXENV=py38
+    - python: 3.7
+      env: TOXENV=py37
     - python: 3.6
       env: TOXENV=py36
     - python: 3.5

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,8 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: System :: Distributed Computing',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35,py36
+envlist = py27,py35,py36,py37,py38
 
 [testenv]
 deps =


### PR DESCRIPTION
I noticed that we are kind of out of date with recent python releases, so adding them to test coverage... Also remove 2.6 since we don't test against it, and 2.x tree is EOL anyway next year.