### PR TITLE
The protocol scheme was added in the phase of finding the active RM.

### DIFF
--- a/tests/test_hadoop_conf.py
+++ b/tests/test_hadoop_conf.py
@@ -104,7 +104,7 @@ class HadoopConfTestCase(TestCase):
 
                 endpoint = hadoop_conf.get_resource_manager_endpoint()
 
-                self.assertEqual('example.com:8022', endpoint)
+                self.assertEqual('http://example.com:8022', endpoint)
                 parse_mock.assert_called_with(hadoop_conf_path + 'yarn-site.xml',
                                               'yarn.resourcemanager.webapp.address')
 
@@ -123,7 +123,7 @@ class HadoopConfTestCase(TestCase):
         check_is_active_rm_mock.return_value = True
         endpoint = hadoop_conf.get_resource_manager_endpoint()
 
-        self.assertEqual('example.com:8022', endpoint)
+        self.assertEqual('http://example.com:8022', endpoint)
         parse_mock.assert_called_with(hadoop_conf_path + 'yarn-site.xml',
                                       'yarn.resourcemanager.webapp.address.rm1')
 
@@ -181,12 +181,12 @@ class HadoopConfTestCase(TestCase):
 
             endpoint = hadoop_conf._get_resource_manager(hadoop_conf.CONF_DIR, None)
 
-            self.assertEqual('example.com:8022', endpoint)
+            self.assertEqual('http://example.com:8022', endpoint)
             parse_mock.assert_called_with(hadoop_conf_path + 'yarn-site.xml', 'yarn.resourcemanager.webapp.address')
 
             endpoint = hadoop_conf._get_resource_manager(hadoop_conf.CONF_DIR, 'rm1')
 
-            self.assertEqual(('example.com:8022'), endpoint)
+            self.assertEqual(('http://example.com:8022'), endpoint)
             parse_mock.assert_called_with(hadoop_conf_path + 'yarn-site.xml', 'yarn.resourcemanager.webapp.address.rm1')
 
             parse_mock.reset_mock()

--- a/tests/test_hadoop_conf.py
+++ b/tests/test_hadoop_conf.py
@@ -3,6 +3,7 @@ from tempfile import NamedTemporaryFile
 
 import mock
 from mock import patch
+from requests import RequestException
 from tests import TestCase
 
 import requests_mock
@@ -171,10 +172,8 @@ class HadoopConfTestCase(TestCase):
 
         # Emulate requests library exception (socket timeout, etc)
         with requests_mock.mock() as requests_get_mock:
-            requests_get_mock.side_effect = Exception('error')
-            # requests_get_mock.get('https://example2:8022/cluster', status_code=200)
-            requests_get_mock.return_value = None
-            self.assertFalse(hadoop_conf.check_is_active_rm('https://example2:8022'))
+            requests_get_mock.get('example2:8022/cluster', exc=RequestException)
+            self.assertFalse(hadoop_conf.check_is_active_rm('example2:8022'))
 
     def test_get_resource_manager(self):
         with patch('yarn_api_client.hadoop_conf.parse') as parse_mock:

--- a/yarn_api_client/hadoop_conf.py
+++ b/yarn_api_client/hadoop_conf.py
@@ -40,9 +40,9 @@ def _get_resource_manager(hadoop_conf_path, rm_id=None):
     if rm_id:
         prop_name = "{name}.{rm_id}".format(name=prop_name, rm_id=rm_id)
 
-    rm_webapp_address = ('https://' if is_https_only else 'http://') + parse(os.path.join(hadoop_conf_path, 'yarn-site.xml'), prop_name)
+    rm_address = parse(os.path.join(hadoop_conf_path, 'yarn-site.xml'), prop_name)
 
-    return rm_webapp_address or None
+    return ('https://' if is_https_only else 'http://') + rm_address if rm_address else None
 
 
 def check_is_active_rm(url, timeout=30, auth=None, verify=True):

--- a/yarn_api_client/hadoop_conf.py
+++ b/yarn_api_client/hadoop_conf.py
@@ -29,7 +29,9 @@ def _is_https_only():
 
 def _get_resource_manager(hadoop_conf_path, rm_id=None):
     # compose property name based on policy (and rm_id)
-    if _is_https_only():
+    is_https_only = _is_https_only()
+
+    if is_https_only:
         prop_name = 'yarn.resourcemanager.webapp.https.address'
     else:
         prop_name = 'yarn.resourcemanager.webapp.address'
@@ -38,7 +40,7 @@ def _get_resource_manager(hadoop_conf_path, rm_id=None):
     if rm_id:
         prop_name = "{name}.{rm_id}".format(name=prop_name, rm_id=rm_id)
 
-    rm_webapp_address = parse(os.path.join(hadoop_conf_path, 'yarn-site.xml'), prop_name)
+    rm_webapp_address = ('https://' if is_https_only else 'http://') + parse(os.path.join(hadoop_conf_path, 'yarn-site.xml'), prop_name)
 
     return rm_webapp_address or None
 
@@ -46,7 +48,8 @@ def _get_resource_manager(hadoop_conf_path, rm_id=None):
 def check_is_active_rm(url, timeout=30, auth=None, verify=True):
     try:
         response = requests.get(url + "/cluster", timeout=timeout, auth=auth, verify=verify)
-    except:
+    except requests.RequestException as e:
+        print("Error to access RM: {}".format(e))
         return False
 
     if response.status_code != 200:


### PR DESCRIPTION
I faced with the issue "Python request: No connection adapters were found for..." when I passed yarn-site.xml file and called the constructor of the class ResourceManager without any arguments.

According to the Yarn documentation https://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/ResourceManagerHA.html
the protocol scheme isn't stored in the values of parameters yarn.resourcemanager.webapp.address.rm-id & yarn.resourcemanager.webapp.https.address.rm-id


