### PR TITLE
Enable builds on Python 3.8-dev pre-releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ language: python
 
 matrix:
   include:
+    - python: 3.8-dev
+      env: TOXENV=py38
     - python: 3.8
       env: TOXENV=py38
     - python: 3.7


### PR DESCRIPTION
The recent Python (3.8.x) releases has been causing some regressions in our code, so this would enable us to learn about those faster. 