### PR TITLE
Fix HTTPS uri parsing and add tests for it

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -52,6 +52,32 @@ class BaseYarnAPITestCase(TestCase):
             with self.assertRaises(ConfigurationError):
                 client.request('/ololo')
 
+    def test_uri_parsing(self):
+        result_uri = base.Uri('localhost')
+        self.assertEqual(result_uri.scheme, 'http')
+        self.assertEqual(result_uri.hostname, 'localhost')
+        self.assertEqual(result_uri.port, None)
+        self.assertEqual(result_uri.is_https, False)
+
+        result_uri = base.Uri('test-domain.com:1234')
+        self.assertEqual(result_uri.scheme, 'http')
+        self.assertEqual(result_uri.hostname, 'test-domain.com')
+        self.assertEqual(result_uri.port, 1234)
+        self.assertEqual(result_uri.is_https, False)
+
+        result_uri = base.Uri('http://123.45.67.89:1234')
+        self.assertEqual(result_uri.scheme, 'http')
+        self.assertEqual(result_uri.hostname, '123.45.67.89')
+        self.assertEqual(result_uri.port, 1234)
+        self.assertEqual(result_uri.is_https, False)
+        
+        result_uri = base.Uri('https://test-domain.com:1234')
+        self.assertEqual(result_uri.scheme, 'https')
+        self.assertEqual(result_uri.hostname, 'test-domain.com')
+        self.assertEqual(result_uri.port, 1234)
+        self.assertEqual(result_uri.is_https, True)
+        
+
     def get_client(self):
         client = base.BaseYarnAPI()
         client.service_uri = base.Uri('example.com:80')

--- a/tests/test_resource_manager.py
+++ b/tests/test_resource_manager.py
@@ -15,7 +15,7 @@ class ResourceManagerTestCase(TestCase):
 
     @patch('yarn_api_client.resource_manager.get_resource_manager_endpoint')
     def test__init__(self, get_config_mock, request_mock):
-        get_config_mock.return_value = "https:localhost"
+        get_config_mock.return_value = "https://localhost"
         rm = ResourceManager()
         get_config_mock.assert_called_with(30, None, True)
         self.assertEqual(rm.service_uri.is_https, True)

--- a/yarn_api_client/base.py
+++ b/yarn_api_client/base.py
@@ -25,7 +25,7 @@ class Response(object):
 
 class Uri(object):
     def __init__(self, service_endpoint):
-        if not (service_endpoint.startswith("http") and service_endpoint.startswith("https")):
+        if not (service_endpoint.startswith("http://") or service_endpoint.startswith("https://")):
             service_endpoint = "http://" + service_endpoint
 
         service_uri = urlparse(service_endpoint)


### PR DESCRIPTION
There was typo in condition (`and` vs `or`) which could cause side effects. This PR fixes it. + There was rare scenario when url has http/https in the beginning of domain. This PR will check proper part of url with `://`.
+
To reduce amount of confusion/random regressions I've added tests for url parsing.

PS: @lresende @kevin-bates The patch for `urlparse` was backported to earlier pythons in sub version (for ex. 3.7.6), so unfortunately this #71 won't completely save us (https://github.com/toidi/hadoop-yarn-api-python-client/issues/69#issuecomment-569135622) . As soon as somebody updates to new version of python, they might get in issues when they use this specific kind of URL `test.com:1234` (with no schema specified). To mitigate this, we have to make sure we cover corner cases - this PR, and then perhaps release another hotfix version on Pypi.