### PR TITLE
Handle responses with empty content

### DIFF
--- a/yarn_api_client/base.py
+++ b/yarn_api_client/base.py
@@ -19,8 +19,12 @@ class Response(object):
     :param requests.Response response: Response for call via requests lib
     """
     def __init__(self, response):
-        #: Dictionary with response data
-        self.data = response.json()
+        #: Dictionary with response data.  Handle cases where content is empty
+        # to prevent JSON decode issues
+        if response.content:
+            self.data = response.json()
+        else:
+            self.data = {}
 
 
 class Uri(object):


### PR DESCRIPTION
Application submission via the REST API does not return a response
body.  This updates ensures that an empty dictionary is returned
in such cases.

Fixes: #76